### PR TITLE
[FEAT] 회원 가입 / 디바이스 토큰 유저 등록

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+
 @Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     alias(libs.plugins.com.android.application)
@@ -20,7 +22,11 @@ android {
         targetSdk = 33
         versionCode = 1
         versionName = "1.0"
-
+        buildConfigField(
+            "String",
+            "BASE_URL",
+            getApiKey("base.url")
+        )
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -45,6 +51,10 @@ android {
         viewBinding = true
         dataBinding = true
     }
+}
+
+fun getApiKey(propertyKey: String): String {
+    return gradleLocalProperties(rootDir).getProperty(propertyKey)
 }
 
 dependencies {

--- a/app/src/main/java/kr/ac/konkuk/gdsc/plantory/data/dto/request/RequestGetUser.kt
+++ b/app/src/main/java/kr/ac/konkuk/gdsc/plantory/data/dto/request/RequestGetUser.kt
@@ -1,4 +1,0 @@
-package kr.ac.konkuk.gdsc.plantory.data.dto.request
-
-class RequestGetUser {
-}

--- a/app/src/main/java/kr/ac/konkuk/gdsc/plantory/data/dto/request/RequestPostRegisterUserDto.kt
+++ b/app/src/main/java/kr/ac/konkuk/gdsc/plantory/data/dto/request/RequestPostRegisterUserDto.kt
@@ -1,0 +1,10 @@
+package kr.ac.konkuk.gdsc.plantory.data.dto.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestPostRegisterUserDto (
+    @SerialName("deviceToken")
+    val deviceToken: String
+)

--- a/app/src/main/java/kr/ac/konkuk/gdsc/plantory/data/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/kr/ac/konkuk/gdsc/plantory/data/interceptor/AuthInterceptor.kt
@@ -1,0 +1,41 @@
+package kr.ac.konkuk.gdsc.plantory.data.interceptor
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kr.ac.konkuk.gdsc.plantory.domain.repository.DataStoreRepository
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import timber.log.Timber
+import javax.inject.Inject
+
+class AuthInterceptor @Inject constructor(
+    @ApplicationContext context: Context,
+    private val json: Json,
+    private val dataStoreRepository: DataStoreRepository
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        runBlocking { Timber.d("deviceToken : ${getDeviceToken()}") }
+        val originalRequest = chain.request()
+
+        val headerRequest = originalRequest.newAuthBuilder()
+            .build()
+
+        return chain.proceed(headerRequest)
+    }
+
+    private fun Request.newAuthBuilder() =
+        this.newBuilder().addHeader(DEVICE_TOKEN, runBlocking(Dispatchers.IO) { getDeviceToken() })
+
+    private suspend fun getDeviceToken(): String {
+        return dataStoreRepository.getDeviceToken()?.first() ?: ""
+    }
+
+    companion object {
+        private const val DEVICE_TOKEN = "deviceToken"
+    }
+}

--- a/app/src/main/java/kr/ac/konkuk/gdsc/plantory/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/kr/ac/konkuk/gdsc/plantory/data/repository/UserRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package kr.ac.konkuk.gdsc.plantory.data.repository
 
+import kr.ac.konkuk.gdsc.plantory.data.dto.request.RequestPostRegisterUserDto
 import kr.ac.konkuk.gdsc.plantory.data.source.UserDataSource
 import kr.ac.konkuk.gdsc.plantory.domain.repository.UserRepository
 import javax.inject.Inject
@@ -7,4 +8,8 @@ import javax.inject.Inject
 class UserRepositoryImpl @Inject constructor(
     private val userDataSource: UserDataSource
 ) : UserRepository {
+    override suspend fun postRegisterUser(requestPostRegisterUserDto: RequestPostRegisterUserDto) : Result<Unit> =
+        runCatching {
+            userDataSource.postRegisterUser(requestPostRegisterUserDto)
+        }
 }

--- a/app/src/main/java/kr/ac/konkuk/gdsc/plantory/data/service/UserService.kt
+++ b/app/src/main/java/kr/ac/konkuk/gdsc/plantory/data/service/UserService.kt
@@ -1,13 +1,13 @@
 package kr.ac.konkuk.gdsc.plantory.data.service
 
-import kr.ac.konkuk.gdsc.plantory.data.dto.request.RequestGetUser
-import kr.ac.konkuk.gdsc.plantory.data.dto.response.ResponseGetUser
+import kr.ac.konkuk.gdsc.plantory.data.dto.request.RequestPostRegisterUserDto
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 
 interface UserService {
-    @GET("")
-    suspend fun getUserData(
-        @Body requestGetUser: RequestGetUser
-    ): ResponseGetUser
+    @POST("api/v1/members")
+    suspend fun postRegisterUser(
+        @Body requestPostRegisterUserDto: RequestPostRegisterUserDto
+    )
 }

--- a/app/src/main/java/kr/ac/konkuk/gdsc/plantory/data/source/UserDataSource.kt
+++ b/app/src/main/java/kr/ac/konkuk/gdsc/plantory/data/source/UserDataSource.kt
@@ -1,10 +1,12 @@
 package kr.ac.konkuk.gdsc.plantory.data.source
 
+import kr.ac.konkuk.gdsc.plantory.data.dto.request.RequestPostRegisterUserDto
 import kr.ac.konkuk.gdsc.plantory.data.service.UserService
 import javax.inject.Inject
 
 class UserDataSource @Inject constructor(
     private val userService: UserService
 ) {
-
+    suspend fun postRegisterUser(requestPostRegisterUserDto: RequestPostRegisterUserDto) =
+        userService.postRegisterUser(requestPostRegisterUserDto)
 }

--- a/app/src/main/java/kr/ac/konkuk/gdsc/plantory/di/RetrofitModule.kt
+++ b/app/src/main/java/kr/ac/konkuk/gdsc/plantory/di/RetrofitModule.kt
@@ -6,6 +6,8 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
+import kr.ac.konkuk.gdsc.plantory.BuildConfig.BASE_URL
+import kr.ac.konkuk.gdsc.plantory.data.interceptor.AuthInterceptor
 import kr.ac.konkuk.gdsc.plantory.di.qualifier.Auth
 import kr.ac.konkuk.gdsc.plantory.di.qualifier.Logger
 import okhttp3.Interceptor
@@ -15,6 +17,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Converter
 import retrofit2.Retrofit
 import javax.inject.Singleton
+
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -32,6 +35,11 @@ object RetrofitModule {
     fun provideHttpLoggingInterceptor(): Interceptor = HttpLoggingInterceptor().apply {
         level = HttpLoggingInterceptor.Level.BODY
     }
+
+    @Provides
+    @Singleton
+    @Auth
+    fun provideAuthInterceptor(interceptor: AuthInterceptor): Interceptor = interceptor
 
     @Provides
     @Singleton
@@ -58,12 +66,10 @@ object RetrofitModule {
         client: OkHttpClient,
         factory: Converter.Factory
     ): Retrofit = Retrofit.Builder()
-        .baseUrl("BASE_URL_HERE")
+        .baseUrl(BASE_URL)
         .client(client)
         .addConverterFactory(factory)
         .build()
-
-
 }
 
 

--- a/app/src/main/java/kr/ac/konkuk/gdsc/plantory/domain/repository/UserRepository.kt
+++ b/app/src/main/java/kr/ac/konkuk/gdsc/plantory/domain/repository/UserRepository.kt
@@ -1,5 +1,7 @@
 package kr.ac.konkuk.gdsc.plantory.domain.repository
 
-interface UserRepository {
+import kr.ac.konkuk.gdsc.plantory.data.dto.request.RequestPostRegisterUserDto
 
+interface UserRepository {
+    suspend fun postRegisterUser(requestPostRegisterUserDto: RequestPostRegisterUserDto): Result<Unit>
 }

--- a/app/src/main/java/kr/ac/konkuk/gdsc/plantory/presentation/MainActivity.kt
+++ b/app/src/main/java/kr/ac/konkuk/gdsc/plantory/presentation/MainActivity.kt
@@ -5,43 +5,79 @@ import androidx.activity.viewModels
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
-import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import com.google.firebase.messaging.FirebaseMessaging
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kr.ac.konkuk.gdsc.plantory.R
 import kr.ac.konkuk.gdsc.plantory.databinding.ActivityMainBinding
 import kr.ac.konkuk.gdsc.plantory.presentation.home.HomeFragment
 import kr.ac.konkuk.gdsc.plantory.util.binding.BindingActivity
+import kr.ac.konkuk.gdsc.plantory.util.view.UiState
 import timber.log.Timber
 
 @AndroidEntryPoint
 class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main) {
     private val viewModel by viewModels<MainViewModel>()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        getDeviceToken()
-        getCurrentToken()
+        navigateToHome()
+        handleDeviceToken()
+        setPostRegisterUserStateObserver()
     }
 
-    private fun getDeviceToken() {
-        lifecycleScope.launch {
-            viewModel.deviceToken.collect { token ->
-                Timber.d("getDeviceToken: $token")
-            }
-        }
-    }
-
-    private fun getCurrentToken() {
-        FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
-            if (!task.isSuccessful) {
-                return@addOnCompleteListener
-            }
-            Timber.d("getCurrentToken: ${task.result}")
-        }
+    private fun navigateToHome() {
         navigateTo<HomeFragment>()
+    }
+
+    private fun handleDeviceToken() {
+        getCurrentDeviceTokenFromFirebase()?.let { currentToken ->
+            checkAndUpdateDeviceToken(currentToken)
+        }
+    }
+
+    private fun getCurrentDeviceTokenFromFirebase(): String? {
+        var token: String? = null
+        FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+                token = task.result
+                Timber.d("Current Token: $token")
+            } else Timber.e("Failed to connect Firebase")
+        }
+        return token
+    }
+
+    private fun checkAndUpdateDeviceToken(currentToken: String) {
+        lifecycleScope.launch {
+            val storedToken = viewModel.getDeviceToken()
+            if (storedToken != currentToken || storedToken.isEmpty()) {
+                viewModel.postRegisterUser()
+            }
+        }
+    }
+
+    private fun setPostRegisterUserStateObserver() {
+        viewModel.postRegisterUserState.flowWithLifecycle(lifecycle).onEach { state ->
+            when (state) {
+                is UiState.Loading -> {
+                }
+
+                is UiState.Success -> {
+                    Timber.d("Success : Register ")
+                }
+
+                is UiState.Failure -> {
+                    Timber.d("Failure : ${state.msg}")
+                }
+
+                is UiState.Empty -> {
+                }
+            }
+        }.launchIn(lifecycleScope)
     }
 
     private inline fun <reified T : Fragment> navigateTo() {

--- a/app/src/main/java/kr/ac/konkuk/gdsc/plantory/presentation/MainViewModel.kt
+++ b/app/src/main/java/kr/ac/konkuk/gdsc/plantory/presentation/MainViewModel.kt
@@ -3,27 +3,39 @@ package kr.ac.konkuk.gdsc.plantory.presentation
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kr.ac.konkuk.gdsc.plantory.data.dto.request.RequestPostRegisterUserDto
 import kr.ac.konkuk.gdsc.plantory.domain.repository.DataStoreRepository
+import kr.ac.konkuk.gdsc.plantory.domain.repository.UserRepository
+import kr.ac.konkuk.gdsc.plantory.util.view.UiState
 import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
-    private val dataStoreRepository: DataStoreRepository
+    private val dataStoreRepository: DataStoreRepository,
+    private val userRepository: UserRepository
 ) : ViewModel() {
-    private val _deviceToken = MutableStateFlow("")
-    val deviceToken: Flow<String> = _deviceToken
+    private val _postRegisterUserState = MutableStateFlow<UiState<Unit>>(UiState.Loading)
+    val postRegisterUserState: StateFlow<UiState<Unit>> = _postRegisterUserState.asStateFlow()
 
-    init {
-        getDeviceToken()
+    suspend fun getDeviceToken(): String {
+        return dataStoreRepository.getDeviceToken()?.first() ?: ""
     }
 
-    private fun getDeviceToken() {
+    fun postRegisterUser() {
         viewModelScope.launch {
-            dataStoreRepository.getDeviceToken()?.collect {
-                _deviceToken.emit(it)
+            userRepository.postRegisterUser(
+                RequestPostRegisterUserDto(
+                    deviceToken = getDeviceToken()
+                )
+            ).onSuccess { response ->
+                _postRegisterUserState.value = UiState.Success(response)
+            }.onFailure { t ->
+                _postRegisterUserState.value = UiState.Failure("${t.message}")
             }
         }
     }


### PR DESCRIPTION
- closed #24 

## 📝 Work Description

- BASE URL
- 파이어베이스로부터 발급받은 디바이스 토큰을 서버에게 POST해 등록함으로서 유저 식별
- 해당 디바이스 토큰이 서버통신의 필수 Header로 이용되므로 Interceptor 만들어 구현

## 👇PR Point
- 보통 자동로그인 여부 확인과 같이 유저의 정보를 불러오고 세팅하는 건 스플래쉬에서 이루어지는데, 플랜토리는 가입 화면도 따로 없고 네트워크가 이상있지 않는 이상 무조건 토큰이 발급되므로 이에 대한 처리가 불필요하다고 느껴져 일단은 메인에서 구현했습니다 ! 배포하기 전 여유가 되면 해당 코드를 스플래쉬로 이전하고 토큰이 없다면 다이얼로그와 함께 앱이 종료되는 걸 구현하는 방법도 있을 것 같아요

- MainViewModel에서 데이터 스토터에 저장된 디바이스 토큰을 불러오는 getDeviceToken을 기존에 flow를 수집하는 방식에서 
```
  suspend fun getDeviceToken(): String {
        return dataStoreRepository.getDeviceToken()?.first() ?: ""
    }
```
으로 String으로 값을 바로 반환하게 변경해보았습니다 ! 고민해봤는데 데이터 스토어에 저장된 디바이스토큰이 앱을 삭제하거나 / 데이터를 지우지 않는 이상 바뀌지 않으므로 이에 따라 앱이 실행중이라면, 애초에 변화를 감지할 일이 없다고 생각되었어요. 또, 생명주기를 파악해야할 일도 아닐 뿐더러 그게 데이터를 가져와서 가공해 활용하는 뷰모델의 역할에도 맞지 않나 싶고 .. 구현된 결과는 같은데 둘 중 어떤 방향이 더 적합하다고 생각하는지 궁금합니다 😲 

## 📣 To Reviewers

전 PR로 인해 이미 디바이스토큰이 데이터 스토어에 저장되어있어서 한번 앱의데이터를 삭제하고 실행해 재발급받으면 서버통신이 진행될 겁니다 ~ 참고해주세요 : ) 또, local properties에 앱 수준 build.gradle properties 참고해 base url 추가해주세요 ~! 