### PR TITLE
[FIX] 홈 / 화면 중복으로 올라오는 듯한 문제 수정

### DIFF
--- a/app/src/main/java/kr/ac/konkuk/gdsc/plantory/presentation/SplashActivity.kt
+++ b/app/src/main/java/kr/ac/konkuk/gdsc/plantory/presentation/SplashActivity.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
+import kr.ac.konkuk.gdsc.plantory.util.activity.applyScreenEnterAnimation
 import kr.ac.konkuk.gdsc.plantory.util.view.UiState
 import timber.log.Timber
 
@@ -83,11 +84,12 @@ class SplashActivity : AppCompatActivity() {
 
     private fun navigateToMain() {
         navigateTo<MainActivity>()
+        applyScreenEnterAnimation()
     }
 
     private inline fun <reified T : Activity> navigateTo() {
         Intent(this, T::class.java).apply {
-            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
             startActivity(this)
         }
     }

--- a/app/src/main/java/kr/ac/konkuk/gdsc/plantory/util/activity/ActivityExt.kt
+++ b/app/src/main/java/kr/ac/konkuk/gdsc/plantory/util/activity/ActivityExt.kt
@@ -2,7 +2,16 @@ package kr.ac.konkuk.gdsc.plantory.util.activity
 
 import android.app.Activity
 import android.view.View
+import kr.ac.konkuk.gdsc.plantory.R
 import kr.ac.konkuk.gdsc.plantory.util.context.hideKeyboard
 fun Activity.hideKeyboard() {
     hideKeyboard(currentFocus ?: View(this))
+}
+
+fun Activity.applyScreenExitAnimation() {
+    overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_right)
+}
+
+fun Activity.applyScreenEnterAnimation() {
+    overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left)
 }

--- a/app/src/main/res/anim/slide_in_left.xml
+++ b/app/src/main/res/anim/slide_in_left.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:fromXDelta="-100%" android:toXDelta="0%"
+        android:fromYDelta="0%" android:toYDelta="0%"
+        android:duration="150"/>
+</set>

--- a/app/src/main/res/anim/slide_in_right.xml
+++ b/app/src/main/res/anim/slide_in_right.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:fromXDelta="100%" android:toXDelta="0%"
+        android:fromYDelta="0%" android:toYDelta="0%"
+        android:duration="150"/>
+</set>

--- a/app/src/main/res/anim/slide_out_left.xml
+++ b/app/src/main/res/anim/slide_out_left.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:fromXDelta="0%" android:toXDelta="-100%"
+        android:fromYDelta="0%" android:toYDelta="0%"
+        android:duration="150"/>
+</set>

--- a/app/src/main/res/anim/slide_out_right.xml
+++ b/app/src/main/res/anim/slide_out_right.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:fromXDelta="0%" android:toXDelta="100%"
+        android:fromYDelta="0%" android:toYDelta="0%"
+        android:duration="150"/>
+</set>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -3,7 +3,6 @@
 
     <style name="Theme.SplashScreen" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowSplashScreenBackground">@color/mint</item>
-        <item name="android:windowSplashScreenAnimationDuration">2000</item>
         <item name="android:windowSplashScreenAnimatedIcon">@drawable/ic_splash_logo</item>
 
     </style>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -22,7 +22,6 @@
     <style name="Theme.Plantory.SplashScreen" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/mint</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_splash_logo</item>
-        <item name="windowSplashScreenAnimationDuration">2000</item>
         <item name="postSplashScreenTheme">@style/Theme.Plantory</item>
     </style>
 


### PR DESCRIPTION
- closed #43 

## 📝 Work Description

- duration 제거
- 진입 애니메이션 추가

## 👇PR Point
- duration을 지정해버리니까 토큰 받아와서 메인으로 넘어갔는데도 스플래쉬가 살아있던 것 같더라구요 해당 부분 지웠습니다
- 액티비티 간의 진입 애니메이션 추가해서 매끄럽게 보이도록 구현했습니다


